### PR TITLE
Change the version to 1.2.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>xmlpull</groupId>
   <artifactId>xmlpull-xpp3-parent</artifactId>
   <!-- Use only 3 versions numbers (major, minor, hotfix) for OSGi compatibility -->
-  <version>1.2.0.Final-SNAPSHOT</version>
+  <version>1.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>XML Pull Parsing API + XPP3 parser parent</name>

--- a/xmlpull-samples/pom.xml
+++ b/xmlpull-samples/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>xmlpull</groupId>
     <artifactId>xmlpull-xpp3-parent</artifactId>
-    <version>1.2.0.Final-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>xmlpull-samples</artifactId>

--- a/xmlpull/pom.xml
+++ b/xmlpull/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>xmlpull</groupId>
     <artifactId>xmlpull-xpp3-parent</artifactId>
-    <version>1.2.0.Final-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>xmlpull</artifactId>

--- a/xpp3_min/pom.xml
+++ b/xpp3_min/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>xmlpull</groupId>
     <artifactId>xmlpull-xpp3-parent</artifactId>
-    <version>1.2.0.Final-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
 
   <groupId>xpp3</groupId>


### PR DESCRIPTION
Given the history of the xmlpull and xpp3 projects, this version better
suits the needs. The "Final suffix was never used before and is not
needed - Maven, Gradle and OSGi will still work as epxected.